### PR TITLE
Load admin boundaries

### DIFF
--- a/src/components/MapView/Boundaries/__snapshots__/index.test.tsx.snap
+++ b/src/components/MapView/Boundaries/__snapshots__/index.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders as expected 1`] = `<div />`;

--- a/src/components/MapView/Boundaries/__snapshots__/index.test.tsx.snap
+++ b/src/components/MapView/Boundaries/__snapshots__/index.test.tsx.snap
@@ -1,3 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders as expected 1`] = `<div />`;
+exports[`renders as expected 1`] = `
+<div>
+  <div
+    class="MapView-container-1"
+  >
+    <div
+      style="height: 100vh; width: 100vw;"
+    />
+    <mock-dateselector />
+  </div>
+</div>
+`;

--- a/src/components/MapView/Boundaries/__snapshots__/index.test.tsx.snap
+++ b/src/components/MapView/Boundaries/__snapshots__/index.test.tsx.snap
@@ -3,12 +3,7 @@
 exports[`renders as expected 1`] = `
 <div>
   <div
-    class="MapView-container-1"
-  >
-    <div
-      style="height: 100vh; width: 100vw;"
-    />
-    <mock-dateselector />
-  </div>
+    style="height: 100vh; width: 100vw;"
+  />
 </div>
 `;

--- a/src/components/MapView/Boundaries/index.test.tsx
+++ b/src/components/MapView/Boundaries/index.test.tsx
@@ -1,14 +1,27 @@
 import React from 'react';
+import ReactMapboxGl from 'react-mapbox-gl';
 import { render } from '@testing-library/react';
 
-import MapView from '..';
+import Boundaries from '.';
 
-// Boundaries need to live in a "Map", so we
-// mock sub-components except for Boundaries
-jest.mock('../Layers', () => 'mock-Layers');
-jest.mock('../DateSelector', () => 'mock-DateSelector');
+const Map = ReactMapboxGl({
+  accessToken: 'TOKEN',
+});
 
 test('renders as expected', () => {
-  const { container } = render(<MapView />);
+  const { container } = render(
+    <Map
+      // eslint-disable-next-line react/style-prop-object
+      style="mapbox://styles/mapbox/light-v10"
+      center={[90, 90]}
+      zoom={[5]}
+      containerStyle={{
+        height: '100vh',
+        width: '100vw',
+      }}
+    >
+      <Boundaries />
+    </Map>,
+  );
   expect(container).toMatchSnapshot();
 });

--- a/src/components/MapView/Boundaries/index.test.tsx
+++ b/src/components/MapView/Boundaries/index.test.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
-import Boundaries from '.';
+import MapView from '..';
+
+// Boundaries need to live in a "Map", so we
+// mock sub-components except for Boundaries
+jest.mock('../Layers', () => 'mock-Layers');
+jest.mock('../DateSelector', () => 'mock-DateSelector');
 
 test('renders as expected', () => {
-  const { container } = render(<Boundaries />);
+  const { container } = render(<MapView />);
   expect(container).toMatchSnapshot();
 });

--- a/src/components/MapView/Boundaries/index.test.tsx
+++ b/src/components/MapView/Boundaries/index.test.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import Boundaries from '.';
+
+test('renders as expected', () => {
+  const { container } = render(<Boundaries />);
+  expect(container).toMatchSnapshot();
+});

--- a/src/components/MapView/Boundaries/index.tsx
+++ b/src/components/MapView/Boundaries/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { GeoJSONLayer } from 'react-mapbox-gl';
+import * as MapboxGL from 'mapbox-gl';
+import adminBoundaries from '../../../config/admin_boundaries.json';
+
+// console.log(adminBoundaries);
+
+const linePaint: MapboxGL.LinePaint = {
+  'line-color': 'grey',
+  'line-width': 1,
+  'line-opacity': 0.3,
+};
+
+function Boundaries() {
+  return (
+    <GeoJSONLayer
+      id="source-admin_boundaries"
+      type="geojson"
+      data={adminBoundaries}
+      linePaint={linePaint}
+    />
+  );
+}
+
+export default Boundaries;

--- a/src/components/MapView/Boundaries/index.tsx
+++ b/src/components/MapView/Boundaries/index.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
+import { get } from 'lodash';
 import { GeoJSONLayer } from 'react-mapbox-gl';
 import * as MapboxGL from 'mapbox-gl';
 import adminBoundaries from '../../../config/admin_boundaries.json';
-
-// console.log(adminBoundaries);
 
 const linePaint: MapboxGL.LinePaint = {
   'line-color': 'grey',
@@ -11,13 +10,26 @@ const linePaint: MapboxGL.LinePaint = {
   'line-opacity': 0.3,
 };
 
+/**
+ * To activate fillOnClick option, we "fill in"
+ * polygons with opacity 0.
+ */
+const fillPaint: MapboxGL.FillPaint = { 'fill-opacity': 0 };
+
+// Get admin data to process.
+function getAdminData(evt: any) {
+  console.log(get(evt.features[0], 'properties.ADM2_PCODE'));
+}
+
 function Boundaries() {
   return (
     <GeoJSONLayer
-      id="source-admin_boundaries"
-      type="geojson"
       data={adminBoundaries}
       linePaint={linePaint}
+      fillPaint={fillPaint}
+      fillOnClick={(evt: any) => {
+        getAdminData(evt);
+      }}
     />
   );
 }

--- a/src/components/MapView/index.test.tsx
+++ b/src/components/MapView/index.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import MapView from '.';
 
 jest.mock('./Layers', () => 'mock-Layers');
+jest.mock('./Boundaries', () => 'mock-Boundaries');
 jest.mock('./DateSelector', () => 'mock-DateSelector');
 
 test('renders as expected', () => {

--- a/src/components/MapView/index.tsx
+++ b/src/components/MapView/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactMapboxGl from 'react-mapbox-gl';
 import { createStyles, WithStyles, withStyles } from '@material-ui/core';
 
+import Boundaries from './Boundaries';
 import Layers from './Layers';
 import DateSelector from './DateSelector';
 import appConfig from '../../config/prism.json';
@@ -27,6 +28,7 @@ function MapView({ classes }: MapViewProps) {
           width: '100vw',
         }}
       >
+        <Boundaries />
         <Layers />
       </Map>
       <DateSelector />


### PR DESCRIPTION
This implements the basic functionalities required to display the admin boundaries and get info on click.

Screenshot:

<img width="1236" alt="Screen Shot 2020-04-16 at 6 25 25 PM" src="https://user-images.githubusercontent.com/16843267/79522103-acc9ea00-800f-11ea-8f37-a26eb9c35743.png">
