### PR TITLE
Fix broken TS import

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,5 +116,8 @@
   },
   "devDependencies": {
     "eslint-import-resolver-typescript": "^2.0.0"
+  },
+  "engines": {
+    "node": "12.x"
   }
 }

--- a/src/components/DataDrawer/Chart/index.tsx
+++ b/src/components/DataDrawer/Chart/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Bar } from 'react-chartjs-2';
-import colormap from 'colormap';
+import * as colormap from 'colormap';
 import { shuffle } from 'lodash';
 import { ChartConfig } from '../../../config/types';
 import { TableData } from '../../../context/tableStateSlice';


### PR DESCRIPTION
Current `master` was giving me (with both Node 12 & 13)

```
Failed to compile.

./src/components/DataDrawer/Chart/index.tsx
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/extensions
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/no-unresolved
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/named
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/no-extraneous-dependencies
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/no-duplicates
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/order
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/no-self-import
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/no-cycle
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/no-named-as-default
  Line 1:1:   Resolve error: unable to load resolver "import/parsers"  import/no-named-as-default-member
  Line 2:21:  Unable to resolve path to module 'react-chartjs-2'       import/no-unresolved
  Line 3:22:  Unable to resolve path to module 'colormap'              import/no-unresolved

Search for the keywords to learn more about each error.
```