### PR TITLE
Force date-picker to display "utc" dates

### DIFF
--- a/src/components/MapView/DateSelector/index.tsx
+++ b/src/components/MapView/DateSelector/index.tsx
@@ -69,6 +69,10 @@ function DateSelector({ availableDates = [], classes }: DateSelectorProps) {
     dispatch(updateDateRange({ startDate: time, endDate: time }));
   }
 
+  // The DatePicker is timezone aware, so we trick it into
+  // displaying UTC dates.
+  const userOffset = new Date().getTimezoneOffset() * 60000;
+
   return (
     <div className={classes.container}>
       <Grid
@@ -79,7 +83,7 @@ function DateSelector({ availableDates = [], classes }: DateSelectorProps) {
         <Grid item xs={2}>
           <DatePicker
             className={classes.datePickerInput}
-            selected={selectedDate.toDate()}
+            selected={selectedDate.utc().toDate()}
             onChange={updateStartDate}
             maxDate={new Date()}
             todayButton="Today"
@@ -88,7 +92,7 @@ function DateSelector({ availableDates = [], classes }: DateSelectorProps) {
             showYearDropdown
             dropdownMode="select"
             customInput={<Input />}
-            includeDates={availableDates.map(d => new Date(d))}
+            includeDates={availableDates.map(d => new Date(d + userOffset))}
           />
         </Grid>
 


### PR DESCRIPTION
Unfortunately, `react-datepicker` is timezone aware. However, we want the data to be displayed with the date it is actually stored at.

In order to achieve this goal, we `trick` the date-picker by adding the user timezone offset to dates, before passing them to the datepicker.