### PR TITLE
Flexible use of admin and data fields for admin level data

### DIFF
--- a/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -50,19 +50,11 @@ function BoundaryLayer({ layer }: { layer: BoundaryLayerProps }) {
       fillOnMouseLeave={(evt: any) => onToggleHover('', evt.target)}
       fillOnClick={(evt: any) => {
         const coordinates = evt.lngLat;
-        const locationName = get(
-          evt.features[0],
-          ['properties', layer.adminLevelNames['1']],
-          '',
-        )
-          .concat(', ')
-          .concat(
-            get(
-              evt.features[0],
-              ['properties', layer.adminLevelNames['2']],
-              '',
-            ),
-          );
+        const locationName = layer.adminLevelNames
+          .map(
+            level => get(evt.features[0], ['properties', level], '') as string,
+          )
+          .join(', ');
         dispatch(showPopup({ coordinates, locationName }));
       }}
     />

--- a/src/components/MapView/Layers/BoundaryLayer/index.tsx
+++ b/src/components/MapView/Layers/BoundaryLayer/index.tsx
@@ -50,9 +50,19 @@ function BoundaryLayer({ layer }: { layer: BoundaryLayerProps }) {
       fillOnMouseLeave={(evt: any) => onToggleHover('', evt.target)}
       fillOnClick={(evt: any) => {
         const coordinates = evt.lngLat;
-        const locationName = get(evt.features[0], 'properties.ADM1_EN', '')
+        const locationName = get(
+          evt.features[0],
+          ['properties', layer.adminLevelNames['1']],
+          '',
+        )
           .concat(', ')
-          .concat(get(evt.features[0], 'properties.ADM2_EN', ''));
+          .concat(
+            get(
+              evt.features[0],
+              ['properties', layer.adminLevelNames['2']],
+              '',
+            ),
+          );
         dispatch(showPopup({ coordinates, locationName }));
       }}
     />

--- a/src/config/layers.json
+++ b/src/config/layers.json
@@ -4,10 +4,10 @@
     "path": "./data/admin_boundaries.json",
     "opacity": 0.8,
     "admin_code": "NSO_CODE",
-    "admin_level_names": {
-      "1": "ADM1_EN",
-      "2": "ADM2_EN"
-    }
+    "admin_level_names": [
+      "ADM1_EN",
+      "ADM2_EN"
+    ]
   },
   "population_below_poverty": {
     "title": "Poverty headcount (aimag)",

--- a/src/config/layers.json
+++ b/src/config/layers.json
@@ -2,12 +2,19 @@
   "admin_boundaries": {
     "type": "boundary",
     "path": "./data/admin_boundaries.json",
-    "opacity": 0.8
+    "opacity": 0.8,
+    "admin_code": "NSO_CODE",
+    "admin_level_names": {
+      "1": "ADM1_EN",
+      "2": "ADM2_EN"
+    }
   },
   "population_below_poverty": {
     "title": "Poverty headcount (aimag)",
     "type": "nso",
     "path": "./data/nso/NSO_Poverty_Headcount_Admin1.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE1",
     "opacity": 0.5,
     "legend": [
@@ -38,6 +45,8 @@
     "title": "Number of disabled people (aimag)",
     "type": "nso",
     "path": "./data/nso/NSO_Disabled_Admin1_Total.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -68,6 +77,8 @@
     "title": "Hay harvest (soum)",
     "type": "nso",
     "path": "./data/nso/NSO_Hay_Harvest_Admin2.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -98,6 +109,8 @@
     "title": "Single-headed elderly households (aimag)",
     "type": "nso",
     "path": "./data/nso/NSO_Single_Elderly_Admin1_Total.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -128,6 +141,8 @@
     "title": "Herder households (soum)",
     "type": "nso",
     "path": "./data/nso/NSO_Herder_HHs_Admin2.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -158,6 +173,8 @@
     "title": "Number of livestock in thousands (soum)",
     "type": "nso",
     "path": "./data/nso/NSO_Livestock_Count_ths_Admin2.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -188,6 +205,8 @@
     "title": "Number of children under 5 (soum)",
     "type": "nso",
     "path": "./data/nso/NSO_Child_U5_Admin2.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -218,6 +237,8 @@
     "title": "Small herder households (aimag)",
     "type": "nso",
     "path": "./data/nso/NSO_Herd_Size_Admin1_LT_200.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE1",
     "opacity": 0.5,
     "legend": [
@@ -248,6 +269,8 @@
     "title": "Total population (soum)",
     "type": "nso",
     "path": "./data/nso/NSO_Population_Admin2_Total.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -516,6 +539,8 @@
     "title": "Hay reserves in metric tonnes (soum)",
     "type": "nso",
     "path": "./data/nso/mVAM_Hay_Reserves.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -546,6 +571,8 @@
     "title": "Fodder reserves in metric tonnes (soum)",
     "type": "nso",
     "path": "./data/nso/mVAM_Fodder_Reserves.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -576,6 +603,8 @@
     "title": "Cash reserves in million MNT (soum)",
     "type": "nso",
     "path": "./data/nso/mVAM_Cash_Reserves.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [
@@ -606,6 +635,8 @@
     "title": "Hay prices (soum)",
     "type": "nso",
     "path": "./data/nso/mVAM_Hay_Price.json",
+    "data_field": "DTVAL_CO",
+    "admin_level": 1,
     "admin_code": "CODE",
     "opacity": 0.5,
     "legend": [

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -133,7 +133,7 @@ export class BoundaryLayerProps extends CommonLayerProps {
   type: 'boundary';
   path: string; // path to admin_boundries.json file - web or local.
   adminCode: string;
-  adminLevelNames: { [key: string]: string };
+  adminLevelNames: string[]; // Ordered (Admin1, Admin2, ...)
 }
 
 export class WMSLayerProps extends CommonLayerProps {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -132,6 +132,8 @@ export class CommonLayerProps {
 export class BoundaryLayerProps extends CommonLayerProps {
   type: 'boundary';
   path: string; // path to admin_boundries.json file - web or local.
+  adminCode: string;
+  adminLevelNames: { [key: string]: string };
 }
 
 export class WMSLayerProps extends CommonLayerProps {
@@ -168,7 +170,14 @@ export class NSOLayerProps extends CommonLayerProps {
   @makeRequired
   legendText: string;
 
-  adminCode: BoundaryKey;
+  @makeRequired
+  adminCode: string;
+
+  @makeRequired
+  adminLevel: string;
+
+  @makeRequired
+  dataField: string;
 }
 
 export class StatsApi {

--- a/src/context/layers/nso.ts
+++ b/src/context/layers/nso.ts
@@ -1,5 +1,5 @@
 import { FeatureCollection } from 'geojson';
-import { isNull, isString } from 'lodash';
+import { get, isNull, isString } from 'lodash';
 import { LayerData, LayerDataParams } from './layer-data';
 import { BoundaryLayerProps, NSOLayerProps } from '../../config/types';
 import { layerDataSelector } from '../mapStateSlice';
@@ -21,12 +21,14 @@ export async function fetchNsoLayerData(
   api: ThunkApi,
 ) {
   const { layer } = params;
-  const { path, adminCode } = layer;
+  const { path, adminCode, dataField } = layer;
   const { getState } = api;
 
-  const adminBoundariesLayer = layerDataSelector(
-    getBoundaryLayerSingleton().id,
-  )(getState()) as LayerData<BoundaryLayerProps> | undefined;
+  const adminBoundaryLayer = getBoundaryLayerSingleton();
+
+  const adminBoundariesLayer = layerDataSelector(adminBoundaryLayer.id)(
+    getState(),
+  ) as LayerData<BoundaryLayerProps> | undefined;
   if (!adminBoundariesLayer || !adminBoundariesLayer.data) {
     // TODO we are assuming here it's already loaded. In the future if layers can be preloaded like boundary this will break.
     throw new Error('Boundary Layer not loaded!');
@@ -39,11 +41,11 @@ export async function fetchNsoLayerData(
 
   const layerData = (rawJSONs || [])
     .map(point => {
-      const adminKey = point[adminCode];
+      const adminKey = point[adminCode] as string;
       if (!adminKey) {
         return undefined;
       }
-      const value = point.DTVAL_CO !== undefined ? point.DTVAL_CO : null;
+      const value = get(point, dataField);
       return { adminKey, value };
     })
     .filter((v): v is DataRecord => v !== undefined);
@@ -53,9 +55,12 @@ export async function fetchNsoLayerData(
     features: adminBoundaries.features
       .map(feature => {
         const { properties } = feature;
-        const nsoCode = (properties || {}).NSO_CODE;
+        const adminBoundaryCode = get(
+          properties,
+          adminBoundaryLayer.adminCode,
+        ) as string;
         const match = layerData.find(
-          ({ adminKey }) => nsoCode.indexOf(adminKey) === 0,
+          ({ adminKey }) => adminBoundaryCode.indexOf(adminKey) === 0,
         );
         if (match && !isNull(match.value)) {
           // Do we want support for non-numeric values (like string colors?)


### PR DESCRIPTION
Fixes #93 
Addresses #29 

In particular:

- One data file with multiple data columns will only need to be imported once
- Names of the admin boundaries used in the tooltips can be configured easily in the admin_level_names of the admin boundary layer
- The name of the column with the admin code can be set in the config for both admin boundaries and data layers